### PR TITLE
feat: Implement task editing, notes, and groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,45 @@
             background: var(--primary-dark);
         }
 
+        /* Group Templates Section */
+        .group-templates-container {
+            background: var(--bg-secondary);
+            padding: 20px;
+            border-radius: 12px;
+            margin-bottom: 30px;
+        }
+
+        .group-templates-container h3 {
+            margin-bottom: 15px;
+        }
+
+        #groupListContainer {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 15px;
+        }
+
+        .group-item {
+            background: var(--bg-primary);
+            padding: 10px 15px;
+            border-radius: 8px;
+            border: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+        }
+
+        .group-item-name {
+            font-weight: 600;
+        }
+
+        .empty-state-small {
+            color: var(--text-tertiary);
+            font-size: 14px;
+        }
+
         /* Task List */
         .task-list {
             background: var(--bg-secondary);
@@ -310,6 +349,7 @@
         .task-title {
             font-size: 16px;
             margin-bottom: 4px;
+            cursor: pointer;
         }
 
         .task-meta {
@@ -362,6 +402,127 @@
 
         .task-action-btn:hover {
             color: var(--primary);
+        }
+
+        /* Modal Styles */
+        .modal-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.6);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+        }
+
+        .modal-content {
+            background: var(--bg-primary);
+            padding: 30px;
+            border-radius: 12px;
+            width: 90%;
+            max-width: 500px;
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
+
+        .modal-content h2 {
+            margin-bottom: 20px;
+        }
+
+        #notesTextarea {
+            width: 100%;
+            min-height: 150px;
+            padding: 10px;
+            border-radius: 8px;
+            border: 1px solid var(--border);
+            background: var(--bg-secondary);
+            color: var(--text-primary);
+            font-size: 16px;
+            margin-bottom: 20px;
+        }
+
+        .modal-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+        }
+
+        .modal-actions button {
+            padding: 10px 20px;
+            border-radius: 8px;
+            border: none;
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        .modal-actions button#saveNotesBtn {
+            background: var(--primary);
+            color: white;
+        }
+
+        .modal-actions button#closeNotesModalBtn {
+            background: var(--bg-tertiary);
+            color: var(--text-primary);
+        }
+
+        .modal-content-large {
+            background: var(--bg-primary);
+            padding: 30px;
+            border-radius: 12px;
+            width: 90%;
+            max-width: 800px;
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
+
+        .manage-groups-layout {
+            display: flex;
+            gap: 30px;
+            margin-bottom: 20px;
+        }
+
+        .group-list-panel {
+            flex: 1;
+            border-right: 1px solid var(--border);
+            padding-right: 30px;
+        }
+
+        .group-tasks-panel {
+            flex: 2;
+        }
+
+        .create-group-form, #addTaskToGroupForm {
+            display: flex;
+            gap: 10px;
+            margin-top: 20px;
+        }
+
+        #modalGroupList, #modalGroupTasksList {
+            min-height: 200px;
+            max-height: 400px;
+            overflow-y: auto;
+        }
+
+        .modal-group-item, .modal-task-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 10px;
+            border-radius: 6px;
+            margin-bottom: 5px;
+            cursor: pointer;
+        }
+
+        .modal-group-item:hover, .modal-group-item.selected {
+            background-color: var(--bg-secondary);
+        }
+
+        .delete-btn {
+            background: none;
+            border: none;
+            color: var(--danger);
+            cursor: pointer;
         }
 
         /* Empty State */
@@ -543,6 +704,16 @@
             </form>
         </div>
 
+        <!-- Group Templates -->
+        <div class="group-templates-container">
+            <h3>Templates</h3>
+            <div id="groupListContainer">
+                <!-- Groups will be rendered here by JS -->
+                <div class="empty-state-small">No templates yet.</div>
+            </div>
+            <button id="manageGroupsBtn" class="add-task-btn" style="width: 100%;">Manage Templates</button>
+        </div>
+
         <!-- Task List -->
         <div class="task-list">
             <div class="task-list-header">
@@ -567,6 +738,53 @@
     <!-- Confetti Canvas -->
     <canvas id="confetti-canvas"></canvas>
 
+    <!-- Notes Modal -->
+    <div id="notesModal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <h2>Task Notes</h2>
+            <textarea id="notesTextarea" placeholder="Add notes here..."></textarea>
+            <div class="modal-actions">
+                <button id="saveNotesBtn">Save</button>
+                <button id="closeNotesModalBtn">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Manage Groups Modal -->
+    <div id="manageGroupsModal" class="modal-overlay" style="display: none;">
+        <div class="modal-content-large">
+            <h2>Manage Templates</h2>
+            <div class="manage-groups-layout">
+                <!-- Left side: List of groups and create new group form -->
+                <div class="group-list-panel">
+                    <h3>My Templates</h3>
+                    <div id="modalGroupList"></div>
+                    <div class="create-group-form">
+                        <input type="text" id="newGroupNameInput" class="task-input" placeholder="New template name...">
+                        <button id="createGroupBtn" class="add-task-btn">Create</button>
+                    </div>
+                </div>
+                <!-- Right side: Tasks for selected group -->
+                <div class="group-tasks-panel">
+                    <h3 id="selectedGroupNameHeader" style="display: none;">Tasks in <span id="selectedGroupName"></span></h3>
+                    <div id="modalGroupTasksList"></div>
+                    <div id="addTaskToGroupForm" style="display: none;">
+                        <input type="text" id="newTaskForGroupInput" class="task-input" placeholder="Task title...">
+                        <select id="newTaskForGroupPriority" class="priority-selector">
+                            <option value="low">Low</option>
+                            <option value="med">Medium</option>
+                            <option value="high">High</option>
+                        </select>
+                        <button id="addTaskToGroupBtn" class="add-task-btn">Add Task</button>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-actions">
+                <button id="closeManageGroupsModalBtn">Close</button>
+            </div>
+        </div>
+    </div>
+
     <script>
         // Daily_Tracker Core Application
         (function() {
@@ -576,10 +794,13 @@
             const STORAGE_KEY = 'daily_tracker_data';
             const SETTINGS_KEY = 'daily_tracker_settings';
             const VERSION = '1.0.0';
+            let currentEditingTaskId = null;
+            let selectedGroupId = null;
             
             // ==================== State Management ====================
             const AppState = {
                 tasks: [],
+                groups: [],
                 settings: {
                     theme: 'light',
                     soundEnabled: true,
@@ -611,6 +832,7 @@
                     localStorage.setItem(STORAGE_KEY, JSON.stringify({
                         version: VERSION,
                         tasks: AppState.tasks,
+                        groups: AppState.groups,
                         xp: AppState.xp,
                         streak: AppState.streak,
                         lastUpdate: Date.now()
@@ -629,6 +851,7 @@
                     if (data) {
                         const parsed = JSON.parse(data);
                         AppState.tasks = parsed.tasks || [];
+                        AppState.groups = parsed.groups || [];
                         AppState.xp = parsed.xp || 0;
                         AppState.streak = parsed.streak || 0;
                     }
@@ -647,6 +870,8 @@
                     id: generateId(),
                     title: title.trim(),
                     priority: priority,
+                    notes: null,
+                    groupId: null,
                     createdAt: Date.now(),
                     completedAt: null,
                     orderIndex: AppState.tasks.length,
@@ -672,6 +897,14 @@
                     }
                     saveToStorage();
                     renderTasks();
+                }
+            }
+
+            function updateTaskTitle(taskId, newTitle) {
+                const task = AppState.tasks.find(t => t.id === taskId);
+                if (task && newTitle) {
+                    task.title = newTitle;
+                    saveToStorage();
                 }
             }
 
@@ -763,6 +996,7 @@
                             </div>
                         </div>
                         <div class="task-actions">
+                            <button class="task-action-btn" onclick="openNotesModal('${task.id}')" aria-label="Notes">📝</button>
                             <button class="task-action-btn" onclick="deleteTask('${task.id}')" aria-label="Delete">🗑️</button>
                         </div>
                     </div>
@@ -776,6 +1010,198 @@
                 const div = document.createElement('div');
                 div.textContent = text;
                 return div.innerHTML;
+            }
+
+            function enableTaskTitleEditing(titleElement, taskId) {
+                // Prevent re-triggering if already in edit mode
+                if (titleElement.querySelector('input')) return;
+
+                const task = AppState.tasks.find(t => t.id === taskId);
+                if (!task) return;
+
+                const originalTitle = task.title;
+
+                // Create an input element
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.value = originalTitle;
+                input.className = 'task-input'; // Reuse a class for styling
+                input.style.width = '100%';
+
+                // Replace title text with input
+                titleElement.innerHTML = '';
+                titleElement.appendChild(input);
+                input.focus();
+                input.select();
+
+                // Event handler for saving or canceling
+                const finishEditing = (shouldSave) => {
+                    const newTitle = input.value.trim();
+                    if (shouldSave && newTitle && newTitle !== originalTitle) {
+                        updateTaskTitle(taskId, newTitle);
+                    }
+                    // Always re-render to ensure UI is correct
+                    renderTasks();
+                };
+
+                input.addEventListener('blur', () => finishEditing(true));
+                input.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        e.preventDefault();
+                        finishEditing(true);
+                    } else if (e.key === 'Escape') {
+                        finishEditing(false);
+                    }
+                });
+            }
+
+            function openNotesModal(taskId) {
+                currentEditingTaskId = taskId;
+                const task = AppState.tasks.find(t => t.id === taskId);
+                if (!task) return;
+
+                document.getElementById('notesTextarea').value = task.notes || '';
+                document.getElementById('notesModal').style.display = 'flex';
+            }
+
+            function closeNotesModal() {
+                document.getElementById('notesModal').style.display = 'none';
+                currentEditingTaskId = null;
+            }
+
+            function saveNotes() {
+                if (!currentEditingTaskId) return;
+
+                const task = AppState.tasks.find(t => t.id === currentEditingTaskId);
+                if (task) {
+                    const notes = document.getElementById('notesTextarea').value;
+                    task.notes = notes.trim() ? notes : null;
+                    saveToStorage();
+                }
+                closeNotesModal();
+            }
+
+            // ==================== Group Template Management ====================
+            function renderGroups() {
+                const container = document.getElementById('groupListContainer');
+                if (AppState.groups.length === 0) {
+                    container.innerHTML = `<div class="empty-state-small">No templates yet.</div>`;
+                    return;
+                }
+                container.innerHTML = AppState.groups.map(group => `
+                    <div class="group-item" onclick="addTasksFromGroup('${group.id}')" title="Add all tasks from ${group.name}">
+                        <span class="group-item-name">${escapeHtml(group.name)}</span>
+                        <span>+</span>
+                    </div>
+                `).join('');
+            }
+
+            function openManageGroupsModal() {
+                selectedGroupId = null;
+                renderGroupsInModal();
+                document.getElementById('selectedGroupNameHeader').style.display = 'none';
+                document.getElementById('addTaskToGroupForm').style.display = 'none';
+                document.getElementById('modalGroupTasksList').innerHTML = '';
+                document.getElementById('manageGroupsModal').style.display = 'flex';
+            }
+
+            function closeManageGroupsModal() {
+                document.getElementById('manageGroupsModal').style.display = 'none';
+            }
+
+            function renderGroupsInModal() {
+                const container = document.getElementById('modalGroupList');
+                container.innerHTML = AppState.groups.map(group => `
+                    <div class="modal-group-item ${group.id === selectedGroupId ? 'selected' : ''}" data-group-id="${group.id}">
+                        <span>${escapeHtml(group.name)}</span>
+                        <button class="delete-btn" data-group-id="${group.id}">🗑️</button>
+                    </div>
+                `).join('');
+            }
+
+            function renderTasksForGroupInModal(groupId) {
+                const group = AppState.groups.find(g => g.id === groupId);
+                if (!group) return;
+
+                document.getElementById('selectedGroupNameHeader').style.display = 'block';
+                document.getElementById('addTaskToGroupForm').style.display = 'flex';
+                document.getElementById('selectedGroupName').textContent = group.name;
+
+                const container = document.getElementById('modalGroupTasksList');
+                container.innerHTML = group.tasks.map(task => `
+                    <div class="modal-task-item">
+                        <span>${escapeHtml(task.title)} (${task.priority})</span>
+                        <button class="delete-btn" data-task-title="${escapeHtml(task.title)}">🗑️</button>
+                    </div>
+                `).join('');
+            }
+
+            function createGroup() {
+                const input = document.getElementById('newGroupNameInput');
+                const name = input.value.trim();
+                if (name) {
+                    const newGroup = {
+                        id: 'group_' + Date.now(),
+                        name: name,
+                        tasks: []
+                    };
+                    AppState.groups.push(newGroup);
+                    saveToStorage();
+                    renderGroups();
+                    renderGroupsInModal();
+                    input.value = '';
+                }
+            }
+
+            function deleteGroup(groupId) {
+                AppState.groups = AppState.groups.filter(g => g.id !== groupId);
+                if (selectedGroupId === groupId) {
+                    selectedGroupId = null;
+                    document.getElementById('selectedGroupNameHeader').style.display = 'none';
+                    document.getElementById('addTaskToGroupForm').style.display = 'none';
+                    document.getElementById('modalGroupTasksList').innerHTML = '';
+                }
+                saveToStorage();
+                renderGroups();
+                renderGroupsInModal();
+            }
+
+            function addTaskToGroup() {
+                if (!selectedGroupId) return;
+                const group = AppState.groups.find(g => g.id === selectedGroupId);
+                if (!group) return;
+
+                const titleInput = document.getElementById('newTaskForGroupInput');
+                const priority = document.getElementById('newTaskForGroupPriority').value;
+                const title = titleInput.value.trim();
+
+                if (title) {
+                    group.tasks.push({ title, priority });
+                    saveToStorage();
+                    renderTasksForGroupInModal(selectedGroupId);
+                    titleInput.value = '';
+                }
+            }
+
+            function deleteTaskFromGroup(groupId, taskTitle) {
+                const group = AppState.groups.find(g => g.id === groupId);
+                if (group) {
+                    group.tasks = group.tasks.filter(t => t.title !== taskTitle);
+                    saveToStorage();
+                    renderTasksForGroupInModal(groupId);
+                }
+            }
+
+            function addTasksFromGroup(groupId) {
+                const group = AppState.groups.find(g => g.id === groupId);
+                if (group) {
+                    group.tasks.forEach(taskDef => {
+                        const task = createTask(taskDef.title, taskDef.priority);
+                        task.groupId = groupId;
+                    });
+                    saveToStorage();
+                    renderTasks();
+                }
             }
 
             // ==================== Drag and Drop ====================
@@ -896,6 +1322,17 @@
 
             // ==================== Event Listeners ====================
             function initEventListeners() {
+                // Task title editing
+                document.getElementById('taskListContainer').addEventListener('click', function(e) {
+                    if (e.target.classList.contains('task-title')) {
+                        const taskItem = e.target.closest('.task-item');
+                        if (taskItem) {
+                            const taskId = taskItem.dataset.taskId;
+                            enableTaskTitleEditing(e.target, taskId);
+                        }
+                    }
+                });
+
                 // Task form submission
                 document.getElementById('taskForm').addEventListener('submit', function(e) {
                     e.preventDefault();
@@ -932,6 +1369,38 @@
                     alert('Settings panel coming soon! 🚀');
                 });
 
+                // Notes Modal Listeners
+                document.getElementById('saveNotesBtn').addEventListener('click', saveNotes);
+                document.getElementById('closeNotesModalBtn').addEventListener('click', closeNotesModal);
+
+                // Group Management Listeners
+                document.getElementById('manageGroupsBtn').addEventListener('click', openManageGroupsModal);
+                document.getElementById('closeManageGroupsModalBtn').addEventListener('click', closeManageGroupsModal);
+                document.getElementById('createGroupBtn').addEventListener('click', createGroup);
+                document.getElementById('addTaskToGroupBtn').addEventListener('click', addTaskToGroup);
+
+                document.getElementById('modalGroupList').addEventListener('click', function(e) {
+                    const groupItem = e.target.closest('.modal-group-item');
+                    if (e.target.classList.contains('delete-btn')) {
+                        const groupId = e.target.dataset.groupId;
+                        if (confirm('Are you sure you want to delete this template?')) {
+                            deleteGroup(groupId);
+                        }
+                    } else if (groupItem) {
+                        selectedGroupId = groupItem.dataset.groupId;
+                        renderGroupsInModal();
+                        renderTasksForGroupInModal(selectedGroupId);
+                    }
+                });
+
+                document.getElementById('modalGroupTasksList').addEventListener('click', function(e) {
+                    if (e.target.classList.contains('delete-btn')) {
+                        const taskTitle = e.target.dataset.taskTitle;
+                        deleteTaskFromGroup(selectedGroupId, taskTitle);
+                    }
+                });
+
+
                 // Keyboard shortcuts
                 document.addEventListener('keydown', function(e) {
                     // N - New task
@@ -965,6 +1434,7 @@
             function init() {
                 loadFromStorage();
                 renderTasks();
+                renderGroups();
                 updateXPBar();
                 updateStreak();
                 initEventListeners();
@@ -978,6 +1448,8 @@
                 // Make functions globally available for onclick handlers
                 window.toggleTaskComplete = toggleTaskComplete;
                 window.deleteTask = deleteTask;
+                window.openNotesModal = openNotesModal;
+                window.addTasksFromGroup = addTasksFromGroup;
             }
 
             // Start the app


### PR DESCRIPTION
This commit introduces three major features to enhance task management capabilities:

1.  **In-Place Task Editing**: Task titles are now editable directly in the list. Clicking on a task title converts it into an input field, and the changes are saved upon losing focus or pressing Enter.

2.  **Task Notes**: A notes feature has been added to each task. Users can click a new notes icon to open a modal window where they can add or edit multi-line notes for a task.

3.  **Task Groups/Templates**: A comprehensive template system has been implemented. Users can now create reusable lists of tasks (templates). A new UI section allows for quickly adding all tasks from a template to the daily list. A detailed management modal provides full CRUD functionality for creating and editing these templates and the tasks within them.

All new data is persisted to localStorage, and the features are integrated into the existing application structure.